### PR TITLE
Case 3. Explicit queue, workers, retries, load shedding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,12 +127,28 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-bom</artifactId>
+                <version>1.15.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>

--- a/src/main/kotlin/ru/quipy/common/utils/TokenBucketRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/TokenBucketRateLimiter.kt
@@ -22,7 +22,7 @@ class TokenBucketRateLimiter(
 
     private val rateLimiterScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
-    private var bucket: AtomicInteger = AtomicInteger(0)
+    private var bucket: AtomicInteger = AtomicInteger(bucketMaxCapacity)
     private var start = System.currentTimeMillis()
     private var nextExpectedWakeUp = start + timeUnit.toMillis(window)
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,18 +2,37 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
+import ru.quipy.common.utils.CompositeRateLimiter
+import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.OngoingWindow
+import ru.quipy.common.utils.RateLimiter
 import ru.quipy.common.utils.SlidingWindowRateLimiter
+import ru.quipy.common.utils.TokenBucketRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
-import java.util.*
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.Int
 
+
+data class PaymentRequest(
+    val paymentId: UUID,
+    val amount: Int,
+    val paymentStartedAt: Long,
+    val deadline: Long,
+    val callback: (Long) -> Unit,
+)
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -38,84 +57,137 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private var rateLimiter: SlidingWindowRateLimiter
+    private var rateLimiter: RateLimiter
     private var ongoingWindow: OngoingWindow
 
-    init {
-        val parsedRateLimit = rateLimitPerSec.toLong()
-        val duration = Duration.ofSeconds(1)
+    private val requestQueue = Channel<PaymentRequest>(Channel.UNLIMITED)
 
-        rateLimiter = SlidingWindowRateLimiter(parsedRateLimit, duration)
+    init {
+        rateLimiter = TokenBucketRateLimiter(
+            parallelRequests,
+            parallelRequests,
+            requestAverageProcessingTime.toMillis(),
+            TimeUnit.MILLISECONDS,
+        )
+
         ongoingWindow = OngoingWindow(parallelRequests)
+
+        val scope = CoroutineScope(Dispatchers.IO)
+
+        repeat(parallelRequests) {
+            scope.launch {
+                processPaymentAsync()
+            }
+        }
     }
 
-    override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
-        logger.warn("[$accountName] Submitting payment request for payment $paymentId")
+    private suspend fun processPaymentAsync() {
+        for (request in requestQueue) {
+            val paymentId = request.paymentId
+            val amount = request.amount
+            val paymentStartedAt = request.paymentStartedAt
+            val deadline = request.deadline
+            val transactionId = UUID.randomUUID()
 
-        val transactionId = UUID.randomUUID()
+            // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
+            // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
+            paymentESService.update(paymentId) {
+                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+            }
 
-        // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
-        // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-        paymentESService.update(paymentId) {
-            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
-        }
+            logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-        logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
+            try {
+                val retries = 3
+                var got = false
+                var delay = 100
 
-        try {
-            ongoingWindow.acquire()
+                for (i in 1..retries) {
+                    if (rateLimiter.tick()) {
+                        got = true
+                        break
+                    } else {
+                        delay(delay + (Math.random() * delay).toLong())
+                        delay *= 2
+                    }
+                }
 
-            while (!rateLimiter.tick()) {}
+                // do load shedding
+                if (!got) {
+                    throw Exception("no available tokens for this request")
+                }
 
-            val request = Request.Builder().run {
-                url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
-                post(emptyBody)
-            }.build()
+                ongoingWindow.acquire()
 
-            val clientWithTimeout = client
+                val request = Request.Builder().run {
+                    url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
+                    post(emptyBody)
+                }.build()
+
+                val clientWithTimeout = client
                     .newBuilder()
-                    .callTimeout(Duration.ofMillis(deadline - paymentStartedAt))
+                    .callTimeout(deadline - now(), TimeUnit.MILLISECONDS)
                     .build()
 
-            clientWithTimeout
-                .newCall(request)
-                .execute()
-                .use { response ->
-                val body = try {
-                    mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                } catch (e: Exception) {
-                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
-                    ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
-                }
+                clientWithTimeout
+                    .newCall(request)
+                    .execute()
+                    .use { response ->
+                        val body = try {
+                            mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
+                        } catch (e: Exception) {
+                            logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
+                            ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
+                        }
 
-                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+                        logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
 
-                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                paymentESService.update(paymentId) {
-                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
-                }
-            }
-        } catch (e: Exception) {
-            when (e) {
-                is SocketTimeoutException -> {
-                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
+                        // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                        // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                        }
+                    }
+            } catch (e: Exception) {
+                when (e) {
+                    is SocketTimeoutException -> {
+                        logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
+                        }
+                    }
+
+                    else -> {
+                        logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
+
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(false, now(), transactionId, reason = e.message)
+                        }
                     }
                 }
-
-                else -> {
-                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = e.message)
-                    }
-                }
+            } finally {
+                ongoingWindow.release()
+                request.callback(now() - paymentStartedAt)
             }
-        } finally {
-            ongoingWindow.release()
         }
+    }
+
+    override suspend fun performPaymentAsync(
+        paymentId: UUID,
+        amount: Int,
+        paymentStartedAt: Long,
+        deadline: Long,
+        callback: (Long) -> Unit,
+    ) {
+        logger.warn("[$accountName] Submitting payment request for payment $paymentId")
+
+        requestQueue.send(PaymentRequest(
+            paymentId = paymentId,
+            amount = amount,
+            paymentStartedAt = paymentStartedAt,
+            deadline = deadline,
+            callback = callback,
+        ))
     }
 
     override fun price() = properties.price

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentMetrics.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentMetrics.kt
@@ -1,0 +1,21 @@
+package ru.quipy.payments.logic
+
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+
+
+@Component
+class PaymentMetrics(
+    private val meterRegistry: MeterRegistry,
+) {
+    private val metricRequestDuration = DistributionSummary
+        .builder("race_m3400_01_avg_payment_processing_time")
+        .description("Average payment processing time")
+        .publishPercentiles(0.5, 0.75, 0.95, 0.99)
+        .publishPercentileHistogram()
+        .register(meterRegistry)
+
+    fun observeRequestDuration(milliseconds: Long) =
+        metricRequestDuration.record(milliseconds.toDouble() / 1000.0)
+}

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
@@ -17,7 +17,13 @@ interface PaymentService {
 
  */
 interface PaymentExternalSystemAdapter {
-    fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    suspend fun performPaymentAsync(
+        paymentId: UUID,
+        amount: Int,
+        paymentStartedAt: Long,
+        deadline: Long,
+        callback: (Long) -> Unit,
+    )
 
     fun name(): String
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -1,21 +1,15 @@
 package ru.quipy.payments.logic
 
+import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import ru.quipy.common.utils.NamedThreadFactory
-import ru.quipy.core.EventSourcingService
-import ru.quipy.payments.api.PaymentAggregate
-import java.time.Duration
 import java.util.*
-import java.util.concurrent.Executors
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 
 
 @Service
 class PaymentSystemImpl(
-    private val paymentAccounts: List<PaymentExternalSystemAdapter>
+    private val paymentAccounts: List<PaymentExternalSystemAdapter>,
+    private val paymentMetrics: PaymentMetrics,
 ) : PaymentService {
     companion object {
         val logger = LoggerFactory.getLogger(PaymentSystemImpl::class.java)
@@ -23,7 +17,16 @@ class PaymentSystemImpl(
 
     override fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         for (account in paymentAccounts) {
-            account.performPaymentAsync(paymentId, amount, paymentStartedAt, deadline)
+            runBlocking {
+                account.performPaymentAsync(
+                    paymentId,
+                    amount,
+                    paymentStartedAt,
+                    deadline,
+                ) { millis ->
+                    paymentMetrics.observeRequestDuration(millis)
+                }
+            }
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,7 @@ spring.datasource.hikari.leak-detection-threshold=2000
 management.metrics.web.server.request.autotime.percentiles=0.95
 management.metrics.export.prometheus.enabled=true
 management.endpoints.web.exposure.include=info,health,prometheus,metrics
+management.endpoint.prometheus.enabled=true
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}


### PR DESCRIPTION
### Проблема:
Сервис приема оплат бодро отвечал на запросы, но через 1-2 минуты на почти каждый запрос начинал отдавать `PAYMENT_TIMEOUT_EXCEEDED` и падать.

### Гипотеза:
На взятии семафоры копится огромная неявная очередь, время ожидания для каждого запроса растет каскадно, вследствие чего время нахождения в нашей системе в скором времени начинало превышать `processingTimeMillis`.

### Что именно сделали:
Мы пытались решить нашу проблему несколькими способами:
- добавили метрику для просмотра итогового времяпрепровождения запроса в нашей системе
- сделали явную и честную очередь, при которой старые запросы будут обрабатываться раньше, чем новые запросы. С текущей семафорой определенный порядок обработки был недетерминирован (какой тред возьмет лок, тот и пойдет на обработку). У этого есть и плюсы, и минусы, но об этом чуть позже.
- сделали воркер пул из `parallelRequests` воркеров, которые разгребают эту самую очередь
- пытались менять `SlidingWindowRateLimiter` на `TokenBucketRateLimiter` и `LeakyBucketRateLimiter`
- делали базовый load shedding по принципу "не смог взять токен - запрос отклоняется"
- добавили к запросам таймауты, чтоб откидывать запросы, которые уже явно старые, и чтоб запросы не задерживались в системе обработки
- добавили ретраи с exponential backoff на взятие рейт лимитера (оказалось абсолютно бесполезно + делали неправильно, т.к. пытались брать токен перед семафорой)

### Почему это НЕ работает:
Не работает это по совершенно простой причине.
Submit rate = 2 rps
Processing rate = 5 (parallel requests) / 4.9 (avgProcessingTime) ~ 1.02 rps
Коэффициент нагруженности системы lambda = submit rate / processing rate ~ 1.96
То есть банально через ~5 секунд обработки у нас в системе будет 10 запросов, 5 из них уже почти обработанные и другие 5 свежие. А через еще 5 секунд у нас будет 5 почти обработанных и 10 нетронутых. Беда.

К слову, метрика, которую мы реализовали, действительно показывает каскадное увеличение времяпрепровождения запроса в системе.

Исходя из теории массового обслуживания, если lambda > 1, то очередь и время нахождения в системе начинает копиться каскадно, а сами запросы просто не успевают обрабатываться. Вследствие чего и возникает наша проблема.

В идеале этот коэффициент должен быть 0.7-0.8 в зависимости от профиля нагрузки. В нашем случае коэффициент превосходит этот порог более чем в ДВА раза.

Load shedding здесь не помогает. Если для примера взять 15 или 30 секунд (интервал сбора метрик у прометеуса), то посмотрим на нашу ситуацию. За 15 секунд:
- придет 30 запросов
- обработается ~15 запросов
- в случае leaky bucket часть запросов будет лежать в очереди
- оставшиеся запросы будут отклонены

Чтобы на протяжении всего теста было >97% success rate, нужно чтоб из 30 запросов было отклонено только 0.9 запроса. Но здесь это невозможно (если не иметь огромнейшую очередь в leaky bucket, которая больше submit rate в тысячи раз, но в таком случае пользы от `LeakyBucketRateLimiter` столько же, сколько от `SlidingWindowRateLimiter` = все равно каскадно накапливается время ожидания).

Чем хороша и плоха честная очередь разгребания?
Плюс: мы начинаем обрабатывать старые запросы раньше, чем новые.
Минус: если старый запрос уже никак не проходит, то мы просто теряем время на него, которое могли бы полезно потратить на обработку других. В теории это решается более умным load shedding 👍🏻  Наверное.

С неявной очередью могло получиться так, что новый запрос перехватит семафору у безнадежного старого запроса, вследствие чего мы заработаем +1 к успешно обработанному трафику.

<img width="960" height="1020" alt="image" src="https://github.com/user-attachments/assets/1a3e61b0-96fc-4dbe-8384-6330eee986c4" />