### PR TITLE
Case 4. Retry-After

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -69,6 +69,8 @@ class APIController {
             val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
             return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
         } catch (e: RateLimitedException) {
+            logger.error("retrying after ${e.retryAfter} seconds...")
+
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", "${e.retryAfter}")

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -3,9 +3,12 @@ package ru.quipy.apigateway
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import ru.quipy.orders.repository.OrderRepository
 import ru.quipy.payments.logic.OrderPayer
+import ru.quipy.payments.logic.RateLimitedException
 import java.util.*
 
 @RestController
@@ -55,16 +58,22 @@ class APIController {
     }
 
     @PostMapping("/orders/{orderId}/payment")
-    fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): PaymentSubmissionDto {
+    fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<PaymentSubmissionDto> {
         val paymentId = UUID.randomUUID()
         val order = orderRepository.findById(orderId)?.let {
             orderRepository.save(it.copy(status = OrderStatus.PAYMENT_IN_PROGRESS))
             it
         } ?: throw IllegalArgumentException("No such order $orderId")
 
-
-        val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
-        return PaymentSubmissionDto(createdAt, paymentId)
+        try {
+            val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
+            return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
+        } catch (e: RateLimitedException) {
+            return ResponseEntity
+                .status(HttpStatus.TOO_MANY_REQUESTS)
+                .header("Retry-After", "${e.retryAfter}")
+                .build()
+        }
     }
 
     class PaymentSubmissionDto(

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -38,7 +38,8 @@ class OrderPayer {
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-        paymentExecutor.submit {
+
+        val future = paymentExecutor.submit {
             val createdEvent = paymentESService.create {
                 it.create(
                     paymentId,
@@ -50,6 +51,15 @@ class OrderPayer {
 
             paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
         }
+
+        try {
+            future.get()
+        } catch (e: Exception) {
+            e.cause?.let {
+                throw it
+            }
+        }
+
         return createdAt
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -5,25 +5,24 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
-import ru.quipy.common.utils.CompositeRateLimiter
 import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.OngoingWindow
 import ru.quipy.common.utils.RateLimiter
 import ru.quipy.common.utils.SlidingWindowRateLimiter
-import ru.quipy.common.utils.TokenBucketRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
-import java.util.UUID
+import java.util.*
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import kotlin.Int
+import kotlin.concurrent.thread
 
 
 data class PaymentRequest(
@@ -57,36 +56,31 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private var rateLimiter: RateLimiter
-    private var ongoingWindow: OngoingWindow
+    private var rateLimiter: RateLimiter = SlidingWindowRateLimiter(
+        rateLimitPerSec.toLong(),
+        Duration.ofSeconds(1),
+    )
+    private var ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
     private val requestQueue = Channel<PaymentRequest>(Channel.UNLIMITED)
 
-    init {
-        rateLimiter = TokenBucketRateLimiter(
-            parallelRequests,
-            parallelRequests,
-            requestAverageProcessingTime.toMillis(),
-            TimeUnit.MILLISECONDS,
-        )
+    private val threadPool = ThreadPoolExecutor(
+        parallelRequests,
+        parallelRequests,
+        60L,
+        TimeUnit.SECONDS,
+        LinkedBlockingQueue(),
+    )
 
-        ongoingWindow = OngoingWindow(parallelRequests)
+    override fun performPaymentAsync(
+        paymentId: UUID,
+        amount: Int,
+        paymentStartedAt: Long,
+        deadline: Long,
+    ) {
+        threadPool.submit {
+            logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
-        val scope = CoroutineScope(Dispatchers.IO)
-
-        repeat(parallelRequests) {
-            scope.launch {
-                processPaymentAsync()
-            }
-        }
-    }
-
-    private suspend fun processPaymentAsync() {
-        for (request in requestQueue) {
-            val paymentId = request.paymentId
-            val amount = request.amount
-            val paymentStartedAt = request.paymentStartedAt
-            val deadline = request.deadline
             val transactionId = UUID.randomUUID()
 
             // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
@@ -98,38 +92,23 @@ class PaymentExternalSystemAdapterImpl(
             logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
             try {
-                val retries = 3
-                var got = false
-                var delay = 100
-
-                for (i in 1..retries) {
-                    if (rateLimiter.tick()) {
-                        got = true
-                        break
-                    } else {
-                        delay(delay + (Math.random() * delay).toLong())
-                        delay *= 2
-                    }
-                }
-
-                // do load shedding
-                if (!got) {
-                    throw Exception("no available tokens for this request")
-                }
-
                 ongoingWindow.acquire()
+
+                if (!rateLimiter.tick()) {
+                    throw Exception("rate limited")
+                }
 
                 val request = Request.Builder().run {
                     url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
                     post(emptyBody)
                 }.build()
 
-                val clientWithTimeout = client
-                    .newBuilder()
-                    .callTimeout(deadline - now(), TimeUnit.MILLISECONDS)
-                    .build()
+                // val clientWithTimeout = client
+                //     .newBuilder()
+                //     .callTimeout(deadline - now(), TimeUnit.MILLISECONDS)
+                //     .build()
 
-                clientWithTimeout
+                client
                     .newCall(request)
                     .execute()
                     .use { response ->
@@ -167,27 +146,8 @@ class PaymentExternalSystemAdapterImpl(
                 }
             } finally {
                 ongoingWindow.release()
-                request.callback(now() - paymentStartedAt)
             }
         }
-    }
-
-    override suspend fun performPaymentAsync(
-        paymentId: UUID,
-        amount: Int,
-        paymentStartedAt: Long,
-        deadline: Long,
-        callback: (Long) -> Unit,
-    ) {
-        logger.warn("[$accountName] Submitting payment request for payment $paymentId")
-
-        requestQueue.send(PaymentRequest(
-            paymentId = paymentId,
-            amount = amount,
-            paymentStartedAt = paymentStartedAt,
-            deadline = deadline,
-            callback = callback,
-        ))
     }
 
     override fun price() = properties.price

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -69,10 +69,10 @@ class PaymentExternalSystemAdapterImpl(
         val plainRateLimit = rateLimitPerSec.toLong()
         val inflightRequestRateLimit = parallelRequests * 1000 / requestAverageProcessingTime.toMillis()
         val realRateLimit = min(plainRateLimit, inflightRequestRateLimit)
-        val estimatedTimeWaiting = (threadPool.queue.size * requestAverageProcessingTime.toMillis()) / realRateLimit
+        val estimatedTimeWaiting = threadPool.queue.size / realRateLimit * 1000
 
         if (now() + estimatedTimeWaiting > deadline) {
-            throw RateLimitedException((requestAverageProcessingTime.toMillis() + 999) / 1000)
+            throw RateLimitedException((estimatedTimeWaiting + 999) / 1000)
         }
 
         threadPool.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,15 +2,10 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
-import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.OngoingWindow
 import ru.quipy.common.utils.RateLimiter
 import ru.quipy.common.utils.SlidingWindowRateLimiter
@@ -22,16 +17,9 @@ import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import kotlin.concurrent.thread
 
-
-data class PaymentRequest(
-    val paymentId: UUID,
-    val amount: Int,
-    val paymentStartedAt: Long,
-    val deadline: Long,
-    val callback: (Long) -> Unit,
-)
+class RateLimitedException(val retryAfter: Long)
+    : Exception("Rate limited, repeat after $retryAfter")
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -61,8 +49,6 @@ class PaymentExternalSystemAdapterImpl(
         Duration.ofSeconds(1),
     )
     private var ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
-
-    private val requestQueue = Channel<PaymentRequest>(Channel.UNLIMITED)
 
     private val threadPool = ThreadPoolExecutor(
         parallelRequests,
@@ -95,7 +81,7 @@ class PaymentExternalSystemAdapterImpl(
                 ongoingWindow.acquire()
 
                 if (!rateLimiter.tick()) {
-                    throw Exception("rate limited")
+                    throw RateLimitedException(1)
                 }
 
                 val request = Request.Builder().run {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 class RateLimitedException(val retryAfter: Long)
-    : Exception("Rate limited, repeat after $retryAfter")
+    : Exception("Rate limited, retry after $retryAfter seconds.")
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -64,6 +64,10 @@ class PaymentExternalSystemAdapterImpl(
         paymentStartedAt: Long,
         deadline: Long,
     ) {
+        if (!rateLimiter.tick()) {
+            throw RateLimitedException((requestAverageProcessingTime.toMillis() + 999) / 1000)
+        }
+
         threadPool.submit {
             logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
@@ -79,10 +83,6 @@ class PaymentExternalSystemAdapterImpl(
 
             try {
                 ongoingWindow.acquire()
-
-                if (!rateLimiter.tick()) {
-                    throw RateLimitedException(1)
-                }
 
                 val request = Request.Builder().run {
                     url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -17,6 +17,7 @@ import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import kotlin.math.min
 
 class RateLimitedException(val retryAfter: Long)
     : Exception("Rate limited, retry after $retryAfter seconds.")
@@ -44,10 +45,11 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private var rateLimiter: RateLimiter = SlidingWindowRateLimiter(
+    private var rateLimiter: SlidingWindowRateLimiter = SlidingWindowRateLimiter(
         rateLimitPerSec.toLong(),
         Duration.ofSeconds(1),
     )
+
     private var ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
     private val threadPool = ThreadPoolExecutor(
@@ -64,7 +66,12 @@ class PaymentExternalSystemAdapterImpl(
         paymentStartedAt: Long,
         deadline: Long,
     ) {
-        if (!rateLimiter.tick()) {
+        val plainRateLimit = rateLimitPerSec.toLong()
+        val inflightRequestRateLimit = parallelRequests * 1000 / requestAverageProcessingTime.toMillis()
+        val realRateLimit = min(plainRateLimit, inflightRequestRateLimit)
+        val estimatedTimeWaiting = (threadPool.queue.size * requestAverageProcessingTime.toMillis()) / realRateLimit
+
+        if (now() + estimatedTimeWaiting > deadline) {
             throw RateLimitedException((requestAverageProcessingTime.toMillis() + 999) / 1000)
         }
 
@@ -83,6 +90,7 @@ class PaymentExternalSystemAdapterImpl(
 
             try {
                 ongoingWindow.acquire()
+                rateLimiter.tickBlocking()
 
                 val request = Request.Builder().run {
                     url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -7,7 +7,6 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.OngoingWindow
-import ru.quipy.common.utils.RateLimiter
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
@@ -17,6 +16,7 @@ import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import kotlin.math.ceil
 import kotlin.math.min
 
 class RateLimitedException(val retryAfter: Long)
@@ -66,13 +66,15 @@ class PaymentExternalSystemAdapterImpl(
         paymentStartedAt: Long,
         deadline: Long,
     ) {
-        val plainRateLimit = rateLimitPerSec.toLong()
-        val inflightRequestRateLimit = parallelRequests * 1000 / requestAverageProcessingTime.toMillis()
+        val plainRateLimit = rateLimitPerSec.toDouble()
+        val inflightRequestRateLimit = parallelRequests * 1000.0 / requestAverageProcessingTime.toMillis()
         val realRateLimit = min(plainRateLimit, inflightRequestRateLimit)
-        val estimatedTimeWaiting = threadPool.queue.size / realRateLimit * 1000
 
-        if (now() + estimatedTimeWaiting > deadline) {
-            throw RateLimitedException((estimatedTimeWaiting + 999) / 1000)
+        val estimatedTimeWaiting = threadPool.queue.size / realRateLimit * 2000 +
+                2 * requestAverageProcessingTime.toMillis()
+
+        if (now() + estimatedTimeWaiting >= deadline) {
+            throw RateLimitedException(ceil(estimatedTimeWaiting / 1000).toLong())
         }
 
         threadPool.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
@@ -17,12 +17,11 @@ interface PaymentService {
 
  */
 interface PaymentExternalSystemAdapter {
-    suspend fun performPaymentAsync(
+    fun performPaymentAsync(
         paymentId: UUID,
         amount: Int,
         paymentStartedAt: Long,
         deadline: Long,
-        callback: (Long) -> Unit,
     )
 
     fun name(): String

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -1,10 +1,8 @@
 package ru.quipy.payments.logic
 
-import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.*
-
 
 @Service
 class PaymentSystemImpl(

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -17,16 +17,12 @@ class PaymentSystemImpl(
 
     override fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         for (account in paymentAccounts) {
-            runBlocking {
-                account.performPaymentAsync(
-                    paymentId,
-                    amount,
-                    paymentStartedAt,
-                    deadline,
-                ) { millis ->
-                    paymentMetrics.observeRequestDuration(millis)
-                }
-            }
+            account.performPaymentAsync(
+                paymentId,
+                amount,
+                paymentStartedAt,
+                deadline,
+            )
         }
     }
 }


### PR DESCRIPTION
### Проблема:
Сервис приема оплат поначалу бодро отвечает на запросы, но через некоторое время (а именно через 30 секунд соответственно параметру `processingTimeMillis`) начинают появляются таймауты.
<img width="496" height="282" alt="image" src="https://github.com/user-attachments/assets/619c54d8-4830-4b3d-a7fb-74d34ccd960d" />


### Гипотеза:
При попытке обработать все запросы мы натыкаемся на каскадное увеличение времени ожидания для каждого запроса, вследствие чего время нахождения в нашей системе в скором времени начинает превышать `processingTimeMillis`.

### Что именно сделали:
Мы перестали пытаться обрабатывать абсолютно все запросы строго в том порядке, в каком они пришли. Если какой-то из них не может взять токен (через `rateLimiter.tick()`), то мы сразу разворачиваем этот запрос обратно и "успокаиваем" генератор нагрузки при помощи хедера `Retry-After`.

### Почему это работает:
Это работает, потому что нашим рейт-лимитером мы создаем back pressure и говорим нашим юзерам (в данном случае бомбардиру) немного подождать (а именно ~avgProcessingTime секунд). Этим действием мы грубо "подрезаем" входящий трафик так, чтоб он соответствовал максимально возможному исходящему трафику. Так мы обеспечиваем устойчивость как нашего сервиса, так и сервиса оплат.

<img width="640" height="420" alt="image" src="https://github.com/user-attachments/assets/fafdd066-9ec7-4de0-9016-beab1e7973f5" />