### PR TITLE
Case 5. Token Bucket / Leaky Bucket

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -68,9 +68,8 @@ class APIController {
         try {
             val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
             return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
-        } catch (e: RateLimitedException) {
-            logger.error("retrying after ${e.retryAfter} seconds...")
-
+        }
+        catch (e: RateLimitedException) {
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", "${e.retryAfter}")

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -46,19 +46,13 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val tokenBucket = TokenBucketRateLimiter(
-        11,
-        11,
-        1,
-        TimeUnit.SECONDS,
-    )
-
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
-        if (!tokenBucket.tick()) {
+        val createdAt = System.currentTimeMillis()
+        val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
+
+        if (createdAt + estimatedWaitingTime >= deadline) {
             throw RateLimitedException(30)
         }
-
-        val createdAt = System.currentTimeMillis()
 
         paymentExecutor.submit {
             val createdEvent = paymentESService.create {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -56,7 +56,8 @@ class OrderPayer {
         val createdAt = System.currentTimeMillis()
 
         if (!leakyBucket.tick()) {
-            throw RateLimitedException(30)
+            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
+            throw RateLimitedException(estimatedWaitingTime / 1000)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -49,7 +49,7 @@ class OrderPayer {
             LeakingBucketRateLimiter(
                 11,
                 Duration.ofSeconds(1),
-                270,
+                660,
             )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -5,13 +5,22 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
+import ru.quipy.common.utils.CompositeRateLimiter
+import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.NamedThreadFactory
+import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
+import java.awt.Composite
+import java.time.Duration
 import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import kotlin.math.ceil
+
+class RateLimitedException(val retryAfter: Long)
+    : Exception("Rate limited, retry after $retryAfter seconds.")
 
 @Service
 class OrderPayer {
@@ -36,10 +45,21 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
+    private val leakyBucket =
+            LeakingBucketRateLimiter(
+                11,
+                Duration.ofSeconds(1),
+                270,
+            )
+
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
+        if (!leakyBucket.tick()) {
+            throw RateLimitedException(30)
+        }
+
         val createdAt = System.currentTimeMillis()
 
-        val future = paymentExecutor.submit {
+        paymentExecutor.submit {
             val createdEvent = paymentESService.create {
                 it.create(
                     paymentId,
@@ -50,14 +70,6 @@ class OrderPayer {
             logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
 
             paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
-        }
-
-        try {
-            future.get()
-        } catch (e: Exception) {
-            e.cause?.let {
-                throw it
-            }
         }
 
         return createdAt

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -64,10 +64,7 @@ class OrderPayer {
 
         if (!rateLimiter.tick()) {
             val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
-
-            if (createdAt + estimatedWaitingTime >= deadline) {
-                throw RateLimitedException(estimatedWaitingTime)
-            }
+            throw RateLimitedException(estimatedWaitingTime)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -56,8 +56,7 @@ class OrderPayer {
         val createdAt = System.currentTimeMillis()
 
         if (!leakyBucket.tick()) {
-            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
-            throw RateLimitedException(estimatedWaitingTime / 1000)
+            throw RateLimitedException(30)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -9,6 +9,7 @@ import ru.quipy.common.utils.CompositeRateLimiter
 import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
+import ru.quipy.common.utils.TokenBucketRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.awt.Composite
@@ -45,15 +46,15 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val leakyBucket =
-            LeakingBucketRateLimiter(
-                11,
-                Duration.ofSeconds(1),
-                660,
-            )
+    private val tokenBucket = TokenBucketRateLimiter(
+        11,
+        30,
+        1,
+        TimeUnit.SECONDS,
+    )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
-        if (!leakyBucket.tick()) {
+        if (!tokenBucket.tick()) {
             throw RateLimitedException(30)
         }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -63,7 +63,7 @@ class OrderPayer {
         val createdAt = System.currentTimeMillis()
 
         if (!rateLimiter.tick()) {
-            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
+            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong()
             throw RateLimitedException(estimatedWaitingTime)
         }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -48,7 +48,7 @@ class OrderPayer {
 
     private val tokenBucket = TokenBucketRateLimiter(
         11,
-        30,
+        11,
         1,
         TimeUnit.SECONDS,
     )

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -46,25 +46,18 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val rateLimiter =
-        CompositeRateLimiter(
-            LeakingBucketRateLimiter(
-                11,
-                Duration.ofSeconds(1),
-                330,
-            ),
-            SlidingWindowRateLimiter(
-                11,
-                Duration.ofSeconds(1),
-            ),
-        )
+    private val leakyBucket = LeakingBucketRateLimiter(
+        11,
+        Duration.ofSeconds(1),
+        270,
+    )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
 
-        if (!rateLimiter.tick()) {
-            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong()
-            throw RateLimitedException(estimatedWaitingTime)
+        if (!leakyBucket.tick()) {
+            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
+            throw RateLimitedException(estimatedWaitingTime / 1000)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -46,18 +46,16 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val leakyBucket = LeakingBucketRateLimiter(
+    private val slidingWindow = SlidingWindowRateLimiter(
         11,
         Duration.ofSeconds(1),
-        270,
     )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
 
-        if (!leakyBucket.tick()) {
-            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
-            throw RateLimitedException(estimatedWaitingTime / 1000)
+        if (!slidingWindow.tick()) {
+            throw RateLimitedException(1)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -46,12 +46,28 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
+    private val rateLimiter =
+        CompositeRateLimiter(
+            LeakingBucketRateLimiter(
+                11,
+                Duration.ofSeconds(1),
+                330,
+            ),
+            SlidingWindowRateLimiter(
+                11,
+                Duration.ofSeconds(1),
+            ),
+        )
+
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-        val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
 
-        if (createdAt + estimatedWaitingTime >= deadline) {
-            throw RateLimitedException(30)
+        if (!rateLimiter.tick()) {
+            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
+
+            if (createdAt + estimatedWaitingTime >= deadline) {
+                throw RateLimitedException(estimatedWaitingTime)
+            }
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -6,6 +6,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
+import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.OngoingWindow
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
@@ -38,6 +39,11 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
+    private val slidingWindow = SlidingWindowRateLimiter(
+        11,
+        Duration.ofSeconds(1),
+    )
+
     private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
@@ -55,6 +61,7 @@ class PaymentExternalSystemAdapterImpl(
 
         try {
             ongoingWindow.acquire()
+            slidingWindow.tickBlocking()
 
             val request = Request.Builder().run {
                 url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -56,7 +56,6 @@ class PaymentExternalSystemAdapterImpl(
 
         try {
             ongoingWindow.acquire()
-            slidingWindow.tickBlocking()
 
             val request = Request.Builder().run {
                 url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -39,11 +39,6 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private val slidingWindow = SlidingWindowRateLimiter(
-        11,
-        Duration.ofSeconds(1),
-    )
-
     private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -13,14 +13,7 @@ import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
-import kotlin.math.ceil
-import kotlin.math.min
 
-class RateLimitedException(val retryAfter: Long)
-    : Exception("Rate limited, retry after $retryAfter seconds.")
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -45,104 +38,78 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private var rateLimiter: SlidingWindowRateLimiter = SlidingWindowRateLimiter(
-        rateLimitPerSec.toLong(),
+    private val slidingWindow = SlidingWindowRateLimiter(
+        properties.rateLimitPerSec.toLong(),
         Duration.ofSeconds(1),
     )
 
-    private var ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
+    private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
-    private val threadPool = ThreadPoolExecutor(
-        parallelRequests,
-        parallelRequests,
-        60L,
-        TimeUnit.SECONDS,
-        LinkedBlockingQueue(),
-    )
+    override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+        logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
-    override fun performPaymentAsync(
-        paymentId: UUID,
-        amount: Int,
-        paymentStartedAt: Long,
-        deadline: Long,
-    ) {
-        val plainRateLimit = rateLimitPerSec.toDouble()
-        val inflightRequestRateLimit = parallelRequests * 1000.0 / requestAverageProcessingTime.toMillis()
-        val realRateLimit = min(plainRateLimit, inflightRequestRateLimit)
+        val transactionId = UUID.randomUUID()
 
-        val estimatedTimeWaiting = threadPool.queue.size / realRateLimit * 2000 +
-                2 * requestAverageProcessingTime.toMillis()
-
-        if (now() + estimatedTimeWaiting >= deadline) {
-            throw RateLimitedException(ceil(estimatedTimeWaiting / 1000).toLong())
+        // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
+        // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
+        paymentESService.update(paymentId) {
+            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
         }
 
-        threadPool.submit {
-            logger.warn("[$accountName] Submitting payment request for payment $paymentId")
+        logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-            val transactionId = UUID.randomUUID()
+        try {
+            ongoingWindow.acquire()
+            slidingWindow.tickBlocking()
 
-            // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
-            // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-            paymentESService.update(paymentId) {
-                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+            val request = Request.Builder().run {
+                url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
+                post(emptyBody)
+            }.build()
+
+            val clientWithTimeout = client
+                    .newBuilder()
+                    .callTimeout(Duration.ofMillis(deadline - paymentStartedAt))
+                    .build()
+
+            clientWithTimeout
+                .newCall(request)
+                .execute()
+                .use { response ->
+                val body = try {
+                    mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
+                } catch (e: Exception) {
+                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
+                    ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
+                }
+
+                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+
+                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                paymentESService.update(paymentId) {
+                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                }
             }
-
-            logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
-
-            try {
-                ongoingWindow.acquire()
-                rateLimiter.tickBlocking()
-
-                val request = Request.Builder().run {
-                    url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
-                    post(emptyBody)
-                }.build()
-
-                // val clientWithTimeout = client
-                //     .newBuilder()
-                //     .callTimeout(deadline - now(), TimeUnit.MILLISECONDS)
-                //     .build()
-
-                client
-                    .newCall(request)
-                    .execute()
-                    .use { response ->
-                        val body = try {
-                            mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                        } catch (e: Exception) {
-                            logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
-                            ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
-                        }
-
-                        logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
-
-                        // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                        // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(body.result, now(), transactionId, reason = body.message)
-                        }
-                    }
-            } catch (e: Exception) {
-                when (e) {
-                    is SocketTimeoutException -> {
-                        logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
-                        }
-                    }
-
-                    else -> {
-                        logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = e.message)
-                        }
+        } catch (e: Exception) {
+            when (e) {
+                is SocketTimeoutException -> {
+                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
                     }
                 }
-            } finally {
-                ongoingWindow.release()
+
+                else -> {
+                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
+
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = e.message)
+                    }
+                }
             }
+        } finally {
+            ongoingWindow.release()
         }
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -38,11 +38,6 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private val slidingWindow = SlidingWindowRateLimiter(
-        properties.rateLimitPerSec.toLong(),
-        Duration.ofSeconds(1),
-    )
-
     private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
@@ -60,7 +55,6 @@ class PaymentExternalSystemAdapterImpl(
 
         try {
             ongoingWindow.acquire()
-            slidingWindow.tickBlocking()
 
             val request = Request.Builder().run {
                 url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")


### PR DESCRIPTION
# Тест 1

### Проблема:
Входящий RPS (15) стабильно выше максимально исходящего (11), и параметр `processingTimeMillis` очень маленький, вследствие чего даже с адаптивным `Retry-After` возникают проблемы.

<img width="1124" height="319" alt="image" src="https://github.com/user-attachments/assets/5e342801-6cbb-4ad4-9102-d8d0fd837991" />

### Гипотеза:
Можно пробовать крутить значение хедера `Retry-After`, который мы отдаем, чтоб успокаивать трафик.

### Что именно сделали:
Мы пробовали увеличивать и уменьшать, а также менять формулу для вычисления `estimatedTimeWaiting`, который передается в `Retry-After`, однако не добились >97% success rate.

upd: решили дропать реквесты сразу, если не смогли взять `.tick()` у рейтлимитера. добились >99% success rate

### Почему это НЕ работает:
Скорее всего это не работает из-за нескольких факторов:
- `averageRequestProcessingTime` - это всего лишь `average`. Для нашего случая, возможно, подошла бы другая метрика - например, которая основывается на квантилях. К примеру, если бы мы знали 95-99q, то смогли бы уменьшить `false positive` ответов (когда мы говорим, что запрос может помариноваться в очереди, но в итоге он все равно помирает по таймауту).
- у бомбардира, возможно, нет механики jitter, при котором он рандомно чуть увеличивает время на ретрай после получения `Retry-After`. Да, мы определенно могли реализовать jitter с нашей стороны, однако мы думаем, что это все-таки обязанность самого бомбардира. К тому же, для нас система генерации нагрузки является черным ящиком - непонятно, отреагировала бы ли она, если бы мы слали `Retry-After` с уже примененным jitter.
- запросы просто слишком долго находятся в очереди на исполнение (в целом, это вытекает из первого фактора)

Кажется, что единственное решение в нашем случае - это пытаться протиснуться через рейт лимитер через `.tick()`, и если запрос получил `false`, то сразу разворачивать с каким-нибудь значением `Retry-After`. Например, с 1 секундой. Это проходило в 4 кейсе.

<img width="2235" height="1084" alt="image" src="https://github.com/user-attachments/assets/c49ac3a8-f28c-4ad5-905c-da3aaa631744" />
<img width="2219" height="665" alt="image" src="https://github.com/user-attachments/assets/fd8d4132-3da5-4451-a0c4-d2075a844e28" />

---
# Тест 2

### Проблема:
График входящего RPS выглядит как синусоида, из-за чего в какие-то моменты мы получаем RPS меньше, чем максимально возможный исходящий, а в какие-то моменты - больше.

### Гипотеза:
На профиль трафика влияет параметр `"profile": "s_0.7_60"`, который, скорее всего, расшифровывается следующим образом:
- "s" - sine - синусоидального вида
- "0.7" - амплитуда => минимум рпс `= 0.7 * base (= 0.7 * 11 ~ 7 rps)`, максимум рпс `= 1.3 * base (= 1.3 * 11 ~ 15 rps)`
- "60" - период в секундах

Получается, имеем дело с "берстами" - резкими скачками рпс.

### Что именно сделали:
Под этот кейс отлично подходит Token Bucket, одно из ключевых особенностей которого - как раз разрешать такие скачки рпс. Однако исходящий рпс все равно необходимо ограничивать, поэтому на выходе из сервиса мы оставили `SlidingWindowRateLimiter`. Для токен бакета было решено поставить `rate = 11`, `bucketSize = 30` (как 2x максимальный рпс, но, кажется, можно было даже оставить 15) и окно в одну секунду.

### Почему это работает:
В нашем токен бакете каждую секунду прибавляется по 11 новых токенов. При трафике ниже 11 rps мы накапливаем неиспользуемые токены (3-4 бесплатных токена каждую секунду) вплоть до лимита = 30 токенов, чтоб в будущем мы смогли заиспользовать их для выдерживания кратковременного повышения трафика до ~15 rps.

![telegram-cloud-photo-size-2-5465479483868973068-y](https://github.com/user-attachments/assets/9662bf63-e80a-42c4-b740-006c89cb96d8)
![telegram-cloud-photo-size-2-5465479483868973070-y](https://github.com/user-attachments/assets/0e0f9388-7aa2-4d7d-8a14-29f7f5ee69d6)


---
# Тест 3

### Проблема:
В этом тесте раз в 90 секунд (на основе параметра `runits`) возникает спайкообразная нагрузка, которая превышает максимально исходящий rps.
<img width="1124" height="324" alt="image" src="https://github.com/user-attachments/assets/ce7d4574-a86f-4779-ac02-9e0fc0faeb63" />

### Гипотеза:
Раз в 90 секунд в наш сервис приходит максимальная нагрузка, и мы должны уметь это разрешать. Скорее всего, здесь понадобится использовать Leaky Bucket вместо Token Bucket, чтоб исходное "ведро", судя по коду, было уже изначально полным.

### Что именно сделали:
На этот кейс мы добавили Leaky Bucket, предварительно посчитав бакет сайз как 15 * 15 (~максимальный входящий рпс * длительность спайка). `SlidingWindowRateLimiter` все так же оставили на выходе из сервиса, чтоб не задудосить сервис оплат.

### Почему это работает:
В данном случае мы тоже разрешаем разрешаем трафику быть спайкообразным, но только на короткие промежутки времени. Причем засчет того, что его профиль - это буквально резкие скачки, то Leaky Bucket здесь подходит чуть лучше Token Bucket как раз из-за того, что наше "ведро" изначально полное, то есть нам не надо накапливать никаких токенов. Однако этот тест предположительно тоже можно пройти с помощью Token Bucket.

![telegram-cloud-photo-size-2-5465479483868973047-y](https://github.com/user-attachments/assets/d10c7265-7216-4916-8e36-173a1124cf21)
![telegram-cloud-photo-size-2-5465479483868973049-y](https://github.com/user-attachments/assets/d130a333-4ba8-44ba-b996-91c35d46a8de)


![meme](https://i.pinimg.com/originals/13/a6/54/13a65432dda7798476058bfd4be954d8.gif)