### PR TITLE
Case 5, Test 1. Sliding Windows, Premature Timeouts

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -70,6 +70,8 @@ class APIController {
             return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
         }
         catch (e: RateLimitedException) {
+            logger.warn("retrying after ${e.retryAfter}")
+
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", "${e.retryAfter}")

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -68,9 +68,8 @@ class APIController {
         try {
             val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
             return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
-        } catch (e: RateLimitedException) {
-            logger.error("retrying after ${e.retryAfter} seconds...")
-
+        }
+        catch (e: RateLimitedException) {
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", "${e.retryAfter}")

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -55,7 +55,8 @@ class OrderPayer {
         val createdAt = System.currentTimeMillis()
 
         if (!slidingWindow.tick()) {
-            throw RateLimitedException(1)
+            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1000 + 1000).toLong()
+            throw RateLimitedException(now() + estimatedWaitingTime)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -46,19 +46,13 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val tokenBucket = TokenBucketRateLimiter(
-        11,
-        11,
-        1,
-        TimeUnit.SECONDS,
-    )
-
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
-        if (!tokenBucket.tick()) {
+        val createdAt = System.currentTimeMillis()
+        val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
+
+        if (createdAt + estimatedWaitingTime >= deadline) {
             throw RateLimitedException(30)
         }
-
-        val createdAt = System.currentTimeMillis()
 
         paymentExecutor.submit {
             val createdEvent = paymentESService.create {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -56,7 +56,8 @@ class OrderPayer {
         val createdAt = System.currentTimeMillis()
 
         if (!leakyBucket.tick()) {
-            throw RateLimitedException(30)
+            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
+            throw RateLimitedException(estimatedWaitingTime / 1000)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -49,7 +49,7 @@ class OrderPayer {
             LeakingBucketRateLimiter(
                 11,
                 Duration.ofSeconds(1),
-                270,
+                660,
             )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -5,13 +5,22 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
+import ru.quipy.common.utils.CompositeRateLimiter
+import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.NamedThreadFactory
+import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
+import java.awt.Composite
+import java.time.Duration
 import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import kotlin.math.ceil
+
+class RateLimitedException(val retryAfter: Long)
+    : Exception("Rate limited, retry after $retryAfter seconds.")
 
 @Service
 class OrderPayer {
@@ -36,10 +45,21 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
+    private val leakyBucket =
+            LeakingBucketRateLimiter(
+                11,
+                Duration.ofSeconds(1),
+                270,
+            )
+
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
+        if (!leakyBucket.tick()) {
+            throw RateLimitedException(30)
+        }
+
         val createdAt = System.currentTimeMillis()
 
-        val future = paymentExecutor.submit {
+        paymentExecutor.submit {
             val createdEvent = paymentESService.create {
                 it.create(
                     paymentId,
@@ -50,14 +70,6 @@ class OrderPayer {
             logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
 
             paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
-        }
-
-        try {
-            future.get()
-        } catch (e: Exception) {
-            e.cause?.let {
-                throw it
-            }
         }
 
         return createdAt

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -64,10 +64,7 @@ class OrderPayer {
 
         if (!rateLimiter.tick()) {
             val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
-
-            if (createdAt + estimatedWaitingTime >= deadline) {
-                throw RateLimitedException(estimatedWaitingTime)
-            }
+            throw RateLimitedException(estimatedWaitingTime)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -56,8 +56,7 @@ class OrderPayer {
         val createdAt = System.currentTimeMillis()
 
         if (!leakyBucket.tick()) {
-            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
-            throw RateLimitedException(estimatedWaitingTime / 1000)
+            throw RateLimitedException(30)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -9,6 +9,7 @@ import ru.quipy.common.utils.CompositeRateLimiter
 import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
+import ru.quipy.common.utils.TokenBucketRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.awt.Composite
@@ -45,15 +46,15 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val leakyBucket =
-            LeakingBucketRateLimiter(
-                11,
-                Duration.ofSeconds(1),
-                660,
-            )
+    private val tokenBucket = TokenBucketRateLimiter(
+        11,
+        30,
+        1,
+        TimeUnit.SECONDS,
+    )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
-        if (!leakyBucket.tick()) {
+        if (!tokenBucket.tick()) {
             throw RateLimitedException(30)
         }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -63,7 +63,7 @@ class OrderPayer {
         val createdAt = System.currentTimeMillis()
 
         if (!rateLimiter.tick()) {
-            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
+            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong()
             throw RateLimitedException(estimatedWaitingTime)
         }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -48,7 +48,7 @@ class OrderPayer {
 
     private val tokenBucket = TokenBucketRateLimiter(
         11,
-        30,
+        11,
         1,
         TimeUnit.SECONDS,
     )

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -46,25 +46,18 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val rateLimiter =
-        CompositeRateLimiter(
-            LeakingBucketRateLimiter(
-                11,
-                Duration.ofSeconds(1),
-                330,
-            ),
-            SlidingWindowRateLimiter(
-                11,
-                Duration.ofSeconds(1),
-            ),
-        )
+    private val leakyBucket = LeakingBucketRateLimiter(
+        11,
+        Duration.ofSeconds(1),
+        270,
+    )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
 
-        if (!rateLimiter.tick()) {
-            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong()
-            throw RateLimitedException(estimatedWaitingTime)
+        if (!leakyBucket.tick()) {
+            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
+            throw RateLimitedException(estimatedWaitingTime / 1000)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -46,18 +46,16 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val leakyBucket = LeakingBucketRateLimiter(
+    private val slidingWindow = SlidingWindowRateLimiter(
         11,
         Duration.ofSeconds(1),
-        270,
     )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
 
-        if (!leakyBucket.tick()) {
-            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
-            throw RateLimitedException(estimatedWaitingTime / 1000)
+        if (!slidingWindow.tick()) {
+            throw RateLimitedException(1)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -46,12 +46,28 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
+    private val rateLimiter =
+        CompositeRateLimiter(
+            LeakingBucketRateLimiter(
+                11,
+                Duration.ofSeconds(1),
+                330,
+            ),
+            SlidingWindowRateLimiter(
+                11,
+                Duration.ofSeconds(1),
+            ),
+        )
+
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-        val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
 
-        if (createdAt + estimatedWaitingTime >= deadline) {
-            throw RateLimitedException(30)
+        if (!rateLimiter.tick()) {
+            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / 11.0) * 1.1 + 1).toLong() * 1000
+
+            if (createdAt + estimatedWaitingTime >= deadline) {
+                throw RateLimitedException(estimatedWaitingTime)
+            }
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -6,6 +6,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
+import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.OngoingWindow
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
@@ -38,6 +39,11 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
+    private val slidingWindow = SlidingWindowRateLimiter(
+        11,
+        Duration.ofSeconds(1),
+    )
+
     private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
@@ -55,6 +61,7 @@ class PaymentExternalSystemAdapterImpl(
 
         try {
             ongoingWindow.acquire()
+            slidingWindow.tickBlocking()
 
             val request = Request.Builder().run {
                 url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -56,7 +56,6 @@ class PaymentExternalSystemAdapterImpl(
 
         try {
             ongoingWindow.acquire()
-            slidingWindow.tickBlocking()
 
             val request = Request.Builder().run {
                 url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -39,11 +39,6 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private val slidingWindow = SlidingWindowRateLimiter(
-        11,
-        Duration.ofSeconds(1),
-    )
-
     private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -13,14 +13,7 @@ import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
-import kotlin.math.ceil
-import kotlin.math.min
 
-class RateLimitedException(val retryAfter: Long)
-    : Exception("Rate limited, retry after $retryAfter seconds.")
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -45,104 +38,78 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private var rateLimiter: SlidingWindowRateLimiter = SlidingWindowRateLimiter(
-        rateLimitPerSec.toLong(),
+    private val slidingWindow = SlidingWindowRateLimiter(
+        properties.rateLimitPerSec.toLong(),
         Duration.ofSeconds(1),
     )
 
-    private var ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
+    private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
-    private val threadPool = ThreadPoolExecutor(
-        parallelRequests,
-        parallelRequests,
-        60L,
-        TimeUnit.SECONDS,
-        LinkedBlockingQueue(),
-    )
+    override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+        logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
-    override fun performPaymentAsync(
-        paymentId: UUID,
-        amount: Int,
-        paymentStartedAt: Long,
-        deadline: Long,
-    ) {
-        val plainRateLimit = rateLimitPerSec.toDouble()
-        val inflightRequestRateLimit = parallelRequests * 1000.0 / requestAverageProcessingTime.toMillis()
-        val realRateLimit = min(plainRateLimit, inflightRequestRateLimit)
+        val transactionId = UUID.randomUUID()
 
-        val estimatedTimeWaiting = threadPool.queue.size / realRateLimit * 2000 +
-                2 * requestAverageProcessingTime.toMillis()
-
-        if (now() + estimatedTimeWaiting >= deadline) {
-            throw RateLimitedException(ceil(estimatedTimeWaiting / 1000).toLong())
+        // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
+        // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
+        paymentESService.update(paymentId) {
+            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
         }
 
-        threadPool.submit {
-            logger.warn("[$accountName] Submitting payment request for payment $paymentId")
+        logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-            val transactionId = UUID.randomUUID()
+        try {
+            ongoingWindow.acquire()
+            slidingWindow.tickBlocking()
 
-            // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
-            // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-            paymentESService.update(paymentId) {
-                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+            val request = Request.Builder().run {
+                url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
+                post(emptyBody)
+            }.build()
+
+            val clientWithTimeout = client
+                    .newBuilder()
+                    .callTimeout(Duration.ofMillis(deadline - paymentStartedAt))
+                    .build()
+
+            clientWithTimeout
+                .newCall(request)
+                .execute()
+                .use { response ->
+                val body = try {
+                    mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
+                } catch (e: Exception) {
+                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
+                    ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
+                }
+
+                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+
+                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                paymentESService.update(paymentId) {
+                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                }
             }
-
-            logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
-
-            try {
-                ongoingWindow.acquire()
-                rateLimiter.tickBlocking()
-
-                val request = Request.Builder().run {
-                    url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
-                    post(emptyBody)
-                }.build()
-
-                // val clientWithTimeout = client
-                //     .newBuilder()
-                //     .callTimeout(deadline - now(), TimeUnit.MILLISECONDS)
-                //     .build()
-
-                client
-                    .newCall(request)
-                    .execute()
-                    .use { response ->
-                        val body = try {
-                            mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                        } catch (e: Exception) {
-                            logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
-                            ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
-                        }
-
-                        logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
-
-                        // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                        // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(body.result, now(), transactionId, reason = body.message)
-                        }
-                    }
-            } catch (e: Exception) {
-                when (e) {
-                    is SocketTimeoutException -> {
-                        logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
-                        }
-                    }
-
-                    else -> {
-                        logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = e.message)
-                        }
+        } catch (e: Exception) {
+            when (e) {
+                is SocketTimeoutException -> {
+                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
                     }
                 }
-            } finally {
-                ongoingWindow.release()
+
+                else -> {
+                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
+
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = e.message)
+                    }
+                }
             }
+        } finally {
+            ongoingWindow.release()
         }
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -41,6 +41,11 @@ class PaymentExternalSystemAdapterImpl(
 
     private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
+    private val slidingWindow = SlidingWindowRateLimiter(
+        rateLimitPerSec.toLong(),
+        Duration.ofSeconds(1),
+    )
+
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
@@ -56,6 +61,7 @@ class PaymentExternalSystemAdapterImpl(
 
         try {
             ongoingWindow.acquire()
+            slidingWindow.tickBlocking()
 
             val request = Request.Builder().run {
                 url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -38,11 +38,6 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private val slidingWindow = SlidingWindowRateLimiter(
-        properties.rateLimitPerSec.toLong(),
-        Duration.ofSeconds(1),
-    )
-
     private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
@@ -60,7 +55,6 @@ class PaymentExternalSystemAdapterImpl(
 
         try {
             ongoingWindow.acquire()
-            slidingWindow.tickBlocking()
 
             val request = Request.Builder().run {
                 url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")


### PR DESCRIPTION
# Тест 1

### Проблема:
Входящий RPS (15) стабильно выше максимально исходящего (11), и параметр `processingTimeMillis` очень маленький, вследствие чего необходимо быстро разворачивать запросы на ретраи.

### Гипотеза:
Здесь, скорее всего, запрос тратит слишком много времени на том, чтоб добраться до external слоя, а там уже клиент таймаутится и уходит.

### Что именно сделали:
Мы добавили рейт лимитер в сервисном слое. Если запрос не смог взять `.tick()`, то мы адаптивно (на основе размера текущей очереди запросов) считаем примерное время ожидания и отдаем его в хедере Retry-After.

### Почему это работает:
Мы предположили, что если рейт лимитить запросы перед их отправкой в `ThreadPoolExecutor`, то мы сможем пользователю быстро сообщить о том, что ему придется попробовать отправить запрос снова. Так мы избавляемся от двух проблем:
1. оверхед `ThreadPoolExecutor` (предположительно ничтожно малый, но все же)
2. неточная проверка на то, успеет ли запрос обработаться, на основе `estimatedWaitingTime` и `avgRequestProcessingTime`. В нашем случае мы располагаем информацией только о "среднем" - это не 95-99q!

<img width="2234" height="948" alt="image" src="https://github.com/user-attachments/assets/dc8484b4-5c31-44ae-9044-af74386e62f0" />
<img width="2244" height="663" alt="image" src="https://github.com/user-attachments/assets/c2bb6525-80ad-4f05-b969-0c120a6e7a6a" />
<img width="2234" height="663" alt="image" src="https://github.com/user-attachments/assets/1d7c756b-ff94-4d4d-9d41-7cf44ba35d00" />
