### PR TITLE
Case 5, Test 2. Token Bucket

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -68,9 +68,8 @@ class APIController {
         try {
             val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
             return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
-        } catch (e: RateLimitedException) {
-            logger.error("retrying after ${e.retryAfter} seconds...")
-
+        }
+        catch (e: RateLimitedException) {
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", "${e.retryAfter}")

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -49,7 +49,7 @@ class OrderPayer {
             LeakingBucketRateLimiter(
                 11,
                 Duration.ofSeconds(1),
-                270,
+                660,
             )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -5,13 +5,22 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
+import ru.quipy.common.utils.CompositeRateLimiter
+import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.NamedThreadFactory
+import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
+import java.awt.Composite
+import java.time.Duration
 import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import kotlin.math.ceil
+
+class RateLimitedException(val retryAfter: Long)
+    : Exception("Rate limited, retry after $retryAfter seconds.")
 
 @Service
 class OrderPayer {
@@ -36,10 +45,21 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
+    private val leakyBucket =
+            LeakingBucketRateLimiter(
+                11,
+                Duration.ofSeconds(1),
+                270,
+            )
+
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
+        if (!leakyBucket.tick()) {
+            throw RateLimitedException(30)
+        }
+
         val createdAt = System.currentTimeMillis()
 
-        val future = paymentExecutor.submit {
+        paymentExecutor.submit {
             val createdEvent = paymentESService.create {
                 it.create(
                     paymentId,
@@ -50,14 +70,6 @@ class OrderPayer {
             logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
 
             paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
-        }
-
-        try {
-            future.get()
-        } catch (e: Exception) {
-            e.cause?.let {
-                throw it
-            }
         }
 
         return createdAt

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -9,6 +9,7 @@ import ru.quipy.common.utils.CompositeRateLimiter
 import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
+import ru.quipy.common.utils.TokenBucketRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.awt.Composite
@@ -45,15 +46,15 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val leakyBucket =
-            LeakingBucketRateLimiter(
-                11,
-                Duration.ofSeconds(1),
-                660,
-            )
+    private val tokenBucket = TokenBucketRateLimiter(
+        11,
+        30,
+        1,
+        TimeUnit.SECONDS,
+    )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
-        if (!leakyBucket.tick()) {
+        if (!tokenBucket.tick()) {
             throw RateLimitedException(30)
         }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -13,14 +13,7 @@ import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
-import kotlin.math.ceil
-import kotlin.math.min
 
-class RateLimitedException(val retryAfter: Long)
-    : Exception("Rate limited, retry after $retryAfter seconds.")
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -45,104 +38,78 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private var rateLimiter: SlidingWindowRateLimiter = SlidingWindowRateLimiter(
-        rateLimitPerSec.toLong(),
+    private val slidingWindow = SlidingWindowRateLimiter(
+        properties.rateLimitPerSec.toLong(),
         Duration.ofSeconds(1),
     )
 
-    private var ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
+    private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
-    private val threadPool = ThreadPoolExecutor(
-        parallelRequests,
-        parallelRequests,
-        60L,
-        TimeUnit.SECONDS,
-        LinkedBlockingQueue(),
-    )
+    override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+        logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
-    override fun performPaymentAsync(
-        paymentId: UUID,
-        amount: Int,
-        paymentStartedAt: Long,
-        deadline: Long,
-    ) {
-        val plainRateLimit = rateLimitPerSec.toDouble()
-        val inflightRequestRateLimit = parallelRequests * 1000.0 / requestAverageProcessingTime.toMillis()
-        val realRateLimit = min(plainRateLimit, inflightRequestRateLimit)
+        val transactionId = UUID.randomUUID()
 
-        val estimatedTimeWaiting = threadPool.queue.size / realRateLimit * 2000 +
-                2 * requestAverageProcessingTime.toMillis()
-
-        if (now() + estimatedTimeWaiting >= deadline) {
-            throw RateLimitedException(ceil(estimatedTimeWaiting / 1000).toLong())
+        // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
+        // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
+        paymentESService.update(paymentId) {
+            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
         }
 
-        threadPool.submit {
-            logger.warn("[$accountName] Submitting payment request for payment $paymentId")
+        logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-            val transactionId = UUID.randomUUID()
+        try {
+            ongoingWindow.acquire()
+            slidingWindow.tickBlocking()
 
-            // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
-            // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-            paymentESService.update(paymentId) {
-                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+            val request = Request.Builder().run {
+                url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
+                post(emptyBody)
+            }.build()
+
+            val clientWithTimeout = client
+                    .newBuilder()
+                    .callTimeout(Duration.ofMillis(deadline - paymentStartedAt))
+                    .build()
+
+            clientWithTimeout
+                .newCall(request)
+                .execute()
+                .use { response ->
+                val body = try {
+                    mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
+                } catch (e: Exception) {
+                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
+                    ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
+                }
+
+                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+
+                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                paymentESService.update(paymentId) {
+                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                }
             }
-
-            logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
-
-            try {
-                ongoingWindow.acquire()
-                rateLimiter.tickBlocking()
-
-                val request = Request.Builder().run {
-                    url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
-                    post(emptyBody)
-                }.build()
-
-                // val clientWithTimeout = client
-                //     .newBuilder()
-                //     .callTimeout(deadline - now(), TimeUnit.MILLISECONDS)
-                //     .build()
-
-                client
-                    .newCall(request)
-                    .execute()
-                    .use { response ->
-                        val body = try {
-                            mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                        } catch (e: Exception) {
-                            logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
-                            ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
-                        }
-
-                        logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
-
-                        // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                        // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(body.result, now(), transactionId, reason = body.message)
-                        }
-                    }
-            } catch (e: Exception) {
-                when (e) {
-                    is SocketTimeoutException -> {
-                        logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
-                        }
-                    }
-
-                    else -> {
-                        logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = e.message)
-                        }
+        } catch (e: Exception) {
+            when (e) {
+                is SocketTimeoutException -> {
+                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
                     }
                 }
-            } finally {
-                ongoingWindow.release()
+
+                else -> {
+                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
+
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = e.message)
+                    }
+                }
             }
+        } finally {
+            ongoingWindow.release()
         }
     }
 


### PR DESCRIPTION
# Тест 2

### Проблема:
График входящего RPS выглядит как синусоида, из-за чего в какие-то моменты мы получаем RPS меньше, чем максимально возможный исходящий, а в какие-то моменты - больше.

### Гипотеза:
На профиль трафика влияет параметр `"profile": "s_0.7_60"`, который, скорее всего, расшифровывается следующим образом:
- "s" - sine - синусоидального вида
- "0.7" - амплитуда => минимум рпс `= 0.7 * base (= 0.7 * 11 ~ 7 rps)`, максимум рпс `= 1.3 * base (= 1.3 * 11 ~ 15 rps)`
- "60" - период в секундах

Получается, имеем дело с "берстами" - резкими скачками рпс.

### Что именно сделали:
Под этот кейс отлично подходит Token Bucket, одно из ключевых особенностей которого - как раз разрешать такие скачки рпс. Однако исходящий рпс все равно необходимо ограничивать, поэтому на выходе из сервиса мы оставили `SlidingWindowRateLimiter`. Для токен бакета было решено поставить `rate = 11`, `bucketSize = 30` (как 2x максимальный рпс, но, кажется, можно было даже оставить 15) и окно в одну секунду.

### Почему это работает:
В нашем токен бакете каждую секунду прибавляется по 11 новых токенов. При трафике ниже 11 rps мы накапливаем неиспользуемые токены (3-4 бесплатных токена каждую секунду) вплоть до лимита = 30 токенов, чтоб в будущем мы смогли заиспользовать их для выдерживания кратковременного повышения трафика до ~15 rps.

![telegram-cloud-photo-size-2-5465479483868973068-y](https://github.com/user-attachments/assets/9662bf63-e80a-42c4-b740-006c89cb96d8)
![telegram-cloud-photo-size-2-5465479483868973070-y](https://github.com/user-attachments/assets/0e0f9388-7aa2-4d7d-8a14-29f7f5ee69d6)