### PR TITLE
Case 5, Test 3. Leaky Bucket

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -68,9 +68,8 @@ class APIController {
         try {
             val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
             return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
-        } catch (e: RateLimitedException) {
-            logger.error("retrying after ${e.retryAfter} seconds...")
-
+        }
+        catch (e: RateLimitedException) {
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", "${e.retryAfter}")

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -49,7 +49,7 @@ class OrderPayer {
             LeakingBucketRateLimiter(
                 11,
                 Duration.ofSeconds(1),
-                270,
+                660,
             )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -5,13 +5,22 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
+import ru.quipy.common.utils.CompositeRateLimiter
+import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.NamedThreadFactory
+import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
+import java.awt.Composite
+import java.time.Duration
 import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import kotlin.math.ceil
+
+class RateLimitedException(val retryAfter: Long)
+    : Exception("Rate limited, retry after $retryAfter seconds.")
 
 @Service
 class OrderPayer {
@@ -36,10 +45,21 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
+    private val leakyBucket =
+            LeakingBucketRateLimiter(
+                11,
+                Duration.ofSeconds(1),
+                270,
+            )
+
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
+        if (!leakyBucket.tick()) {
+            throw RateLimitedException(30)
+        }
+
         val createdAt = System.currentTimeMillis()
 
-        val future = paymentExecutor.submit {
+        paymentExecutor.submit {
             val createdEvent = paymentESService.create {
                 it.create(
                     paymentId,
@@ -50,14 +70,6 @@ class OrderPayer {
             logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
 
             paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
-        }
-
-        try {
-            future.get()
-        } catch (e: Exception) {
-            e.cause?.let {
-                throw it
-            }
         }
 
         return createdAt

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -13,14 +13,7 @@ import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
-import kotlin.math.ceil
-import kotlin.math.min
 
-class RateLimitedException(val retryAfter: Long)
-    : Exception("Rate limited, retry after $retryAfter seconds.")
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -45,104 +38,78 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
-    private var rateLimiter: SlidingWindowRateLimiter = SlidingWindowRateLimiter(
-        rateLimitPerSec.toLong(),
+    private val slidingWindow = SlidingWindowRateLimiter(
+        properties.rateLimitPerSec.toLong(),
         Duration.ofSeconds(1),
     )
 
-    private var ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
+    private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
-    private val threadPool = ThreadPoolExecutor(
-        parallelRequests,
-        parallelRequests,
-        60L,
-        TimeUnit.SECONDS,
-        LinkedBlockingQueue(),
-    )
+    override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+        logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
-    override fun performPaymentAsync(
-        paymentId: UUID,
-        amount: Int,
-        paymentStartedAt: Long,
-        deadline: Long,
-    ) {
-        val plainRateLimit = rateLimitPerSec.toDouble()
-        val inflightRequestRateLimit = parallelRequests * 1000.0 / requestAverageProcessingTime.toMillis()
-        val realRateLimit = min(plainRateLimit, inflightRequestRateLimit)
+        val transactionId = UUID.randomUUID()
 
-        val estimatedTimeWaiting = threadPool.queue.size / realRateLimit * 2000 +
-                2 * requestAverageProcessingTime.toMillis()
-
-        if (now() + estimatedTimeWaiting >= deadline) {
-            throw RateLimitedException(ceil(estimatedTimeWaiting / 1000).toLong())
+        // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
+        // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
+        paymentESService.update(paymentId) {
+            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
         }
 
-        threadPool.submit {
-            logger.warn("[$accountName] Submitting payment request for payment $paymentId")
+        logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-            val transactionId = UUID.randomUUID()
+        try {
+            ongoingWindow.acquire()
+            slidingWindow.tickBlocking()
 
-            // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
-            // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
-            paymentESService.update(paymentId) {
-                it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(now() - paymentStartedAt))
+            val request = Request.Builder().run {
+                url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
+                post(emptyBody)
+            }.build()
+
+            val clientWithTimeout = client
+                    .newBuilder()
+                    .callTimeout(Duration.ofMillis(deadline - paymentStartedAt))
+                    .build()
+
+            clientWithTimeout
+                .newCall(request)
+                .execute()
+                .use { response ->
+                val body = try {
+                    mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
+                } catch (e: Exception) {
+                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
+                    ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
+                }
+
+                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+
+                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                paymentESService.update(paymentId) {
+                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
+                }
             }
-
-            logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
-
-            try {
-                ongoingWindow.acquire()
-                rateLimiter.tickBlocking()
-
-                val request = Request.Builder().run {
-                    url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
-                    post(emptyBody)
-                }.build()
-
-                // val clientWithTimeout = client
-                //     .newBuilder()
-                //     .callTimeout(deadline - now(), TimeUnit.MILLISECONDS)
-                //     .build()
-
-                client
-                    .newCall(request)
-                    .execute()
-                    .use { response ->
-                        val body = try {
-                            mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                        } catch (e: Exception) {
-                            logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
-                            ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
-                        }
-
-                        logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
-
-                        // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                        // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(body.result, now(), transactionId, reason = body.message)
-                        }
-                    }
-            } catch (e: Exception) {
-                when (e) {
-                    is SocketTimeoutException -> {
-                        logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
-                        }
-                    }
-
-                    else -> {
-                        logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(false, now(), transactionId, reason = e.message)
-                        }
+        } catch (e: Exception) {
+            when (e) {
+                is SocketTimeoutException -> {
+                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
                     }
                 }
-            } finally {
-                ongoingWindow.release()
+
+                else -> {
+                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
+
+                    paymentESService.update(paymentId) {
+                        it.logProcessing(false, now(), transactionId, reason = e.message)
+                    }
+                }
             }
+        } finally {
+            ongoingWindow.release()
         }
     }
 


### PR DESCRIPTION
# Тест 3

### Проблема:
В этом тесте раз в 90 секунд (на основе параметра `runits`) возникает спайкообразная нагрузка, которая превышает максимально исходящий rps.
<img width="1124" height="324" alt="image" src="https://github.com/user-attachments/assets/ce7d4574-a86f-4779-ac02-9e0fc0faeb63" />

### Гипотеза:
Раз в 90 секунд в наш сервис приходит максимальная нагрузка, и мы должны уметь это разрешать. Скорее всего, здесь понадобится использовать Leaky Bucket вместо Token Bucket, чтоб исходное "ведро", судя по коду, было уже изначально полным.

### Что именно сделали:
На этот кейс мы добавили Leaky Bucket, предварительно посчитав бакет сайз как 15 * 15 (~максимальный входящий рпс * длительность спайка). `SlidingWindowRateLimiter` все так же оставили на выходе из сервиса, чтоб не задудосить сервис оплат.

### Почему это работает:
В данном случае мы тоже разрешаем разрешаем трафику быть спайкообразным, но только на короткие промежутки времени. Причем засчет того, что его профиль - это буквально резкие скачки, то Leaky Bucket здесь подходит чуть лучше Token Bucket как раз из-за того, что наше "ведро" изначально полное, то есть нам не надо накапливать никаких токенов. Однако этот тест предположительно тоже можно пройти с помощью Token Bucket.

![telegram-cloud-photo-size-2-5465479483868973047-y](https://github.com/user-attachments/assets/d10c7265-7216-4916-8e36-173a1124cf21)
![telegram-cloud-photo-size-2-5465479483868973049-y](https://github.com/user-attachments/assets/d130a333-4ba8-44ba-b996-91c35d46a8de)