### PR TITLE
Case 6. Retries

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import ru.quipy.orders.repository.OrderRepository
 import ru.quipy.payments.logic.OrderPayer
-import ru.quipy.payments.logic.RateLimitedException
+import ru.quipy.payments.logic.ShouldRetryException
 import java.util.*
 
 @RestController
@@ -69,7 +69,9 @@ class APIController {
             val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
             return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
         }
-        catch (e: RateLimitedException) {
+        catch (e: ShouldRetryException) {
+            logger.warn("retrying for $orderId")
+
             return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
                 .header("Retry-After", "${e.retryAfter}")

--- a/src/main/kotlin/ru/quipy/common/utils/TokenBucketRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/TokenBucketRateLimiter.kt
@@ -22,7 +22,7 @@ class TokenBucketRateLimiter(
 
     private val rateLimiterScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
-    private var bucket: AtomicInteger = AtomicInteger(bucketMaxCapacity)
+    private var bucket: AtomicInteger = AtomicInteger(0)
     private var start = System.currentTimeMillis()
     private var nextExpectedWakeUp = start + timeUnit.toMillis(window)
 

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -46,6 +46,9 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
+    private val outgoingRps = 11.0
+    private val reqProcessingTime = 1000
+
     private val slidingWindow = SlidingWindowRateLimiter(
         11,
         Duration.ofSeconds(1),
@@ -55,7 +58,8 @@ class OrderPayer {
         val createdAt = System.currentTimeMillis()
 
         if (!slidingWindow.tick()) {
-            throw RateLimitedException(1)
+            val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / outgoingRps) + reqProcessingTime).toLong()
+            throw RateLimitedException(createdAt + estimatedWaitingTime)
         }
 
         paymentExecutor.submit {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -20,8 +20,6 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import kotlin.math.ceil
 
-class RateLimitedException(val retryAfter: Long)
-    : Exception("Rate limited, retry after $retryAfter seconds.")
 
 @Service
 class OrderPayer {
@@ -46,11 +44,11 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val outgoingRps = 11.0
-    private val reqProcessingTime = 1000
+    private val outgoingRps = 10.0
+    private val reqProcessingTime = 2000
 
     private val slidingWindow = SlidingWindowRateLimiter(
-        11,
+        10,
         Duration.ofSeconds(1),
     )
 
@@ -59,10 +57,13 @@ class OrderPayer {
 
         if (!slidingWindow.tick()) {
             val estimatedWaitingTime = (ceil(paymentExecutor.queue.size / outgoingRps) + reqProcessingTime).toLong()
-            throw RateLimitedException(createdAt + estimatedWaitingTime)
+
+            if (createdAt + estimatedWaitingTime > deadline) {
+                throw ShouldRetryException(createdAt + estimatedWaitingTime)
+            }
         }
 
-        paymentExecutor.submit {
+        val future = paymentExecutor.submit {
             val createdEvent = paymentESService.create {
                 it.create(
                     paymentId,
@@ -73,6 +74,14 @@ class OrderPayer {
             logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
 
             paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
+        }
+
+        try {
+            future.get()
+        } catch (e: Exception) {
+            e.cause?.let {
+                throw it
+            }
         }
 
         return createdAt

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,11 +2,12 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
-import ru.quipy.common.utils.LeakingBucketRateLimiter
 import ru.quipy.common.utils.OngoingWindow
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
@@ -14,7 +15,12 @@ import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.random.Random
 
+class ShouldRetryException(val retryAfter: Long)
+    : Exception("Retry after $retryAfter timestamp.")
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -46,7 +52,13 @@ class PaymentExternalSystemAdapterImpl(
 
     private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
-    override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    override fun performPaymentAsync(
+        paymentId: UUID,
+        amount: Int,
+        paymentStartedAt: Long,
+        deadline: Long,
+        callback: (Long) -> Unit,
+    ) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
         val transactionId = UUID.randomUUID()
@@ -59,59 +71,105 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-        try {
-            ongoingWindow.acquire()
-            rateLimiter.tickBlocking()
+        val baseDelay = 100 // ms
+        val maxDelay: Long = 16000 // ms
+        val highQuantileProcessingTime = 2000 // ms
 
-            val request = Request.Builder().run {
-                url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
-                post(emptyBody)
-            }.build()
+        repeat(5) { attempt ->
+            try {
+                ongoingWindow.acquire()
+                rateLimiter.tickBlocking()
 
-            val clientWithTimeout = client
+                if (deadline < now() + highQuantileProcessingTime) {
+                    throw ShouldRetryException(now() + highQuantileProcessingTime)
+                }
+
+                val request = Request.Builder().run {
+                    url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")
+                    post(emptyBody)
+                }.build()
+
+                val clientWithTimeout = client
                     .newBuilder()
-                    .callTimeout(Duration.ofMillis(deadline - paymentStartedAt))
+                    .callTimeout(Duration.ofMillis(deadline - now()))
                     .build()
 
-            clientWithTimeout
-                .newCall(request)
-                .execute()
-                .use { response ->
-                val body = try {
-                    mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                } catch (e: Exception) {
-                    logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
-                    ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
-                }
+                clientWithTimeout
+                    .newCall(request)
+                    .execute()
+                    .use { response ->
+                        val body = try {
+                            mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
+                        } catch (e: Exception) {
+                            logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.code}, reason: ${response.body?.string()}")
+                            ExternalSysResponse(transactionId.toString(), paymentId.toString(),false, e.message)
+                        }
 
-                logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+                        logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}, code: ${response.code}")
 
-                // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
-                // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
-                paymentESService.update(paymentId) {
-                    it.logProcessing(body.result, now(), transactionId, reason = body.message)
-                }
-            }
-        } catch (e: Exception) {
-            when (e) {
-                is SocketTimeoutException -> {
-                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
+                        if (
+                            !body.result &&
+                            body.message?.contains("Temporary error") == false &&
+                            response.code != 429 &&
+                            response.code !in 500..599
+                        ) {
+                            callback(now())
+                            return
+                        }
+
+                        if (body.result) {
+                            // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
+                            // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
+                            paymentESService.update(paymentId) {
+                                it.logProcessing(true, now(), transactionId, reason = body.message)
+                            }
+
+                            callback(now())
+                            return
+                        }
+                    }
+            } catch (e: Exception) {
+                when (e) {
+                    is SocketTimeoutException -> {
+                        logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", e)
+
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(false, now(), transactionId, reason = "Request timeout.")
+                        }
+                    }
+
+                    is ShouldRetryException -> {
+                        throw e
+                    }
+
+                    else -> {
+                        logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
+
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(false, now(), transactionId, reason = e.message)
+                        }
                     }
                 }
 
-                else -> {
-                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", e)
-
-                    paymentESService.update(paymentId) {
-                        it.logProcessing(false, now(), transactionId, reason = e.message)
-                    }
-                }
+                callback(now())
+                return
+            } finally {
+                ongoingWindow.release()
             }
-        } finally {
-            ongoingWindow.release()
+
+            val backoff = baseDelay * (2.0.pow(attempt)).toLong()
+            val cappedBackoff = min(backoff, maxDelay)
+            val jittered = Random.nextLong(0, cappedBackoff)
+
+            logger.warn("transaction $transactionId, payment $paymentId, attempt $attempt, going for delay $jittered")
+            runBlocking { delay(jittered) }
         }
+
+        paymentESService.update(paymentId) {
+            it.logProcessing(false, now(), transactionId, reason = "Request fail")
+        }
+
+        callback(now())
     }
 
     override fun price() = properties.price

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -39,6 +39,11 @@ class PaymentExternalSystemAdapterImpl(
 
     private val client = OkHttpClient.Builder().build()
 
+    private val rateLimiter = SlidingWindowRateLimiter(
+        rateLimitPerSec.toLong(),
+        Duration.ofSeconds(1),
+    )
+
     private val ongoingWindow: OngoingWindow = OngoingWindow(parallelRequests)
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
@@ -56,6 +61,7 @@ class PaymentExternalSystemAdapterImpl(
 
         try {
             ongoingWindow.acquire()
+            rateLimiter.tickBlocking()
 
             val request = Request.Builder().run {
                 url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount")

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
@@ -22,6 +22,7 @@ interface PaymentExternalSystemAdapter {
         amount: Int,
         paymentStartedAt: Long,
         deadline: Long,
+        callback: (Long) -> Unit,
     )
 
     fun name(): String

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -20,7 +20,9 @@ class PaymentSystemImpl(
                 amount,
                 paymentStartedAt,
                 deadline,
-            )
+            ) { timestamp ->
+                paymentMetrics.observeRequestDuration(timestamp - paymentStartedAt)
+            }
         }
     }
 }


### PR DESCRIPTION
### Проблема:
Клиенты таймаутятся, хотя по факту входящий рпс меньше максимально исходящего
![telegram-cloud-photo-size-2-5195051369202056206-y](https://github.com/user-attachments/assets/b0ebe289-3542-4a6f-8460-833813154d5c)
![telegram-cloud-photo-size-2-5195051369202056207-y](https://github.com/user-attachments/assets/e9043b00-f2e5-4670-b909-7e843b2339c3)

В логах имеются следующие записи:
```
2025-10-30T23:11:12.120+03:00  WARN 43148 --- [sion-executor-7] r.q.p.l.PaymentExternalSystemAdapter     : [acc-8] Payment processed for txId: e93e2510-067d-43d2-97d7-1f2381e4e055, payment: 04c82e3d-31f3-46ca-89b9-290dd0406c88, succeeded: false, message: Temporary error
2025-10-30T23:11:12.227+03:00  WARN 43148 --- [ion-executor-15] r.q.p.l.PaymentExternalSystemAdapter     : [acc-8] Payment processed for txId: 3ef54412-291b-47df-9591-dabb50130ed7, payment: f3db3600-9ccf-46ca-9d57-db255fb15cf4, succeeded: false, message: Temporary error
2025-10-30T23:11:12.228+03:00  WARN 43148 --- [sion-executor-5] r.q.p.l.PaymentExternalSystemAdapter     : [acc-8] Payment processed for txId: 1d7d6b88-ff5d-43aa-9200-6f8f3a7dff11, payment: 56853b55-a421-4014-a79d-56f859507102, succeeded: true, message: null
2025-10-30T23:11:12.957+03:00  WARN 43148 --- [ion-executor-12] r.q.p.l.PaymentExternalSystemAdapter     : [acc-8] Payment processed for txId: 548bf824-6674-4dd5-a801-e6bf16e4f3ee, payment: caf6483b-c38f-4e45-9770-fc5e13c9099b, succeeded: false, message: Temporary error
```

Причем `Temporary error` приходит с кодом 200.

### Гипотеза:
На стороне сервиса оплаты происходят какие-то временные ошибки, однако наша система считает их за окончательную ошибку и помечает этот запрос как зафейлившийся. 

### Что именно сделали:
Мы добавили обработку `Temporary error` при помощи ретраев с экспоненциальным бэкоффом с джиттером. Если мы внезапно встречаем эту самую ошибку, то НЕ помечаем запрос как упавший, а идем на ретрай после какой-то задержки.

Параметры задержки следующие:
- `baseDelay` = 100 мс
- `maxDelay` = 16000 мс (можно и меньше, потому что пользователь не готов столько ждать)
- база бэкоффа - 2
- `jitter` - брали рандом от 0 до высчитанного значения
- максимальное количество попыток - 5 (3.5/0.7)

Итоговая задержка между ретраями: `Random.nextLong(0, min(maxDelay, baseDelay * (2.0.pow(attempt))))

Дополнительно завели гистограмму и посчитали 99q для времени процессинга - получили ~2 секунды. Записали в переменную `highQuantileProcessingTime` и при каждом ретрае проверяли `if (deadline < now() + highQuantileProcessingTime`: если true, то разворачивали запрос с хедером `Retry-After`.

### Почему это работает:
Мы подумали, что раз `Temporary error` - это временная ошибка, то нам стоит просто поретраиться несколько раз, пока можем. Если все-таки не получится, то запрос просто можно отправить на `Retry-After`. Особенно если считать примерное время выполнения запроса как `highQuantileProcessingTime`, то мы учитываем почти худший случай, что предостерегает нас от внезапных ошибок с таймаутом. 

![telegram-cloud-photo-size-2-5197592340573860869-y](https://github.com/user-attachments/assets/d8b11a18-6801-449d-a222-060da60062e8)
![telegram-cloud-photo-size-2-5197592340573860870-y](https://github.com/user-attachments/assets/39530d20-ff24-42d0-99d2-f26795f24a29)
![telegram-cloud-photo-size-2-5197592340573860871-y](https://github.com/user-attachments/assets/9ddd3810-b321-4557-8f7d-585215f4a1b3)

<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/9bd9efba-c46c-4b7f-b945-c8a2b4e7d2c1" />
