### PR TITLE
Case 7. Timeouts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mvn dependency:go-offline
 COPY src src
 RUN mvn package
 
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-alpine-3.22.
 
 COPY --from=build /app/target/*.jar /high-load-course.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mvn dependency:go-offline
 COPY src src
 RUN mvn package
 
-FROM eclipse-temurin:17-alpine-3.22.
+FROM eclipse-temurin:17-alpine-3.22
 
 COPY --from=build /app/target/*.jar /high-load-course.jar
 

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import ru.quipy.orders.repository.OrderRepository
 import ru.quipy.payments.logic.OrderPayer
+import ru.quipy.payments.logic.PaymentMetrics
 import ru.quipy.payments.logic.ShouldRetryException
 import java.util.*
 
@@ -21,6 +22,9 @@ class APIController {
 
     @Autowired
     private lateinit var orderPayer: OrderPayer
+
+    @Autowired
+    private lateinit var paymentMetrics: PaymentMetrics
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {
@@ -70,6 +74,7 @@ class APIController {
             return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
         }
         catch (e: ShouldRetryException) {
+            paymentMetrics.metricSentWithRetryAfterInc()
             logger.warn("retrying for $orderId")
 
             return ResponseEntity

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -45,7 +45,7 @@ class OrderPayer {
     )
 
     private val outgoingRps = 8.0
-    private val reqProcessingTime = 1200L // ms
+    private val reqProcessingTime = 1700L // ms
 
     private val slidingWindow = SlidingWindowRateLimiter(
         outgoingRps.toLong(),

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -44,11 +44,11 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val outgoingRps = 10.0
-    private val reqProcessingTime = 2000
+    private val outgoingRps = 8.0
+    private val reqProcessingTime = 1200L // ms
 
     private val slidingWindow = SlidingWindowRateLimiter(
-        10,
+        outgoingRps.toLong(),
         Duration.ofSeconds(1),
     )
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -16,6 +16,7 @@ import java.io.InterruptedIOException
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
+import java.util.concurrent.TimeUnit
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.random.Random
@@ -59,6 +60,7 @@ class PaymentExternalSystemAdapterImpl(
         paymentStartedAt: Long,
         deadline: Long,
         callback: (Long) -> Unit,
+        onRetry: () -> Unit,
     ) {
         logger.warn("[$accountName] Submitting payment request for payment $paymentId")
 
@@ -74,15 +76,17 @@ class PaymentExternalSystemAdapterImpl(
 
         val baseDelay = 100L // ms
         val maxDelay = 16000L // ms
-        val highQuantileProcessingTime = 6000L // ms
+        val quantileProcessingTime = 1700L // ms
 
-        repeat(5) { attempt ->
+        repeat(8) { attempt ->
+            var shouldRetry = false
+
             try {
                 ongoingWindow.acquire()
                 rateLimiter.tickBlocking()
 
-                if (deadline < now() + requestAverageProcessingTime.toMillis()) {
-                    throw ShouldRetryException(now() + requestAverageProcessingTime.toMillis())
+                if (deadline < now() + quantileProcessingTime) {
+                    throw ShouldRetryException(now() + quantileProcessingTime)
                 }
 
                 val request = Request.Builder().run {
@@ -92,7 +96,7 @@ class PaymentExternalSystemAdapterImpl(
 
                 val clientWithTimeout = client
                     .newBuilder()
-                    .callTimeout(Duration.ofMillis(highQuantileProcessingTime))
+                    .callTimeout(quantileProcessingTime, TimeUnit.MILLISECONDS)
                     .build()
 
                 clientWithTimeout
@@ -128,6 +132,8 @@ class PaymentExternalSystemAdapterImpl(
                             callback(now())
                             return
                         }
+
+                        shouldRetry = true
                     }
             } catch (e: Exception) {
                 when (e) {
@@ -144,7 +150,7 @@ class PaymentExternalSystemAdapterImpl(
                     }
 
                     is InterruptedIOException -> {
-                        throw ShouldRetryException(now() + requestAverageProcessingTime.toMillis())
+                        shouldRetry = true
                     }
 
                     else -> {
@@ -157,17 +163,22 @@ class PaymentExternalSystemAdapterImpl(
                 }
 
                 callback(now())
-                return
             } finally {
                 ongoingWindow.release()
             }
 
+            if (!shouldRetry) {
+                return
+            }
+
             val backoff = baseDelay * (2.0.pow(attempt)).toLong()
             val cappedBackoff = min(backoff, maxDelay)
-            val jittered = Random.nextLong(0, cappedBackoff)
+            val jittered = Random.nextLong(baseDelay, cappedBackoff + 1)
 
             logger.warn("transaction $transactionId, payment $paymentId, attempt $attempt, going for delay $jittered")
             runBlocking { delay(jittered) }
+
+            onRetry()
         }
 
         paymentESService.update(paymentId) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -12,6 +12,7 @@ import ru.quipy.common.utils.OngoingWindow
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
+import java.io.InterruptedIOException
 import java.net.SocketTimeoutException
 import java.time.Duration
 import java.util.*
@@ -71,17 +72,17 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
 
-        val baseDelay = 100 // ms
-        val maxDelay: Long = 16000 // ms
-        val highQuantileProcessingTime = 2000 // ms
+        val baseDelay = 100L // ms
+        val maxDelay = 16000L // ms
+        val highQuantileProcessingTime = 6000L // ms
 
         repeat(5) { attempt ->
             try {
                 ongoingWindow.acquire()
                 rateLimiter.tickBlocking()
 
-                if (deadline < now() + highQuantileProcessingTime) {
-                    throw ShouldRetryException(now() + highQuantileProcessingTime)
+                if (deadline < now() + requestAverageProcessingTime.toMillis()) {
+                    throw ShouldRetryException(now() + requestAverageProcessingTime.toMillis())
                 }
 
                 val request = Request.Builder().run {
@@ -91,7 +92,7 @@ class PaymentExternalSystemAdapterImpl(
 
                 val clientWithTimeout = client
                     .newBuilder()
-                    .callTimeout(Duration.ofMillis(deadline - now()))
+                    .callTimeout(Duration.ofMillis(highQuantileProcessingTime))
                     .build()
 
                 clientWithTimeout
@@ -140,6 +141,10 @@ class PaymentExternalSystemAdapterImpl(
 
                     is ShouldRetryException -> {
                         throw e
+                    }
+
+                    is InterruptedIOException -> {
+                        throw ShouldRetryException(now() + requestAverageProcessingTime.toMillis())
                     }
 
                     else -> {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentMetrics.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentMetrics.kt
@@ -1,5 +1,6 @@
 package ru.quipy.payments.logic
 
+import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.stereotype.Component
@@ -9,13 +10,29 @@ import org.springframework.stereotype.Component
 class PaymentMetrics(
     private val meterRegistry: MeterRegistry,
 ) {
-    private val metricRequestDuration = DistributionSummary
+    private val requestDuration = DistributionSummary
         .builder("race_m3400_01_avg_payment_processing_time")
         .description("Average payment processing time")
         .publishPercentiles(0.5, 0.75, 0.95, 0.99)
         .publishPercentileHistogram()
         .register(meterRegistry)
 
+    private val sentWithRetryAfter = Counter
+        .builder("race_m3400_01_sent_with_retry_after_total")
+        .description("Retry after responses")
+        .register(meterRegistry)
+
+    private val retriesCounter = Counter
+        .builder("race_m3400_01_request_retries_total")
+        .description("Retries on external client")
+        .register(meterRegistry)
+
     fun observeRequestDuration(milliseconds: Long) =
-        metricRequestDuration.record(milliseconds.toDouble() / 1000.0)
+        requestDuration.record(milliseconds.toDouble() / 1000.0)
+
+    fun metricSentWithRetryAfterInc() =
+        sentWithRetryAfter.increment()
+
+    fun metricRetriesCounterInc() =
+        retriesCounter.increment()
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
@@ -23,6 +23,7 @@ interface PaymentExternalSystemAdapter {
         paymentStartedAt: Long,
         deadline: Long,
         callback: (Long) -> Unit,
+        onRetry: () -> Unit,
     )
 
     fun name(): String

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -15,14 +15,22 @@ class PaymentSystemImpl(
 
     override fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         for (account in paymentAccounts) {
+            val callback = { timestamp: Long ->
+                paymentMetrics.observeRequestDuration(timestamp - paymentStartedAt)
+            }
+
+            val onRetry = {
+                paymentMetrics.metricRetriesCounterInc()
+            }
+
             account.performPaymentAsync(
                 paymentId,
                 amount,
                 paymentStartedAt,
                 deadline,
-            ) { timestamp ->
-                paymentMetrics.observeRequestDuration(timestamp - paymentStartedAt)
-            }
+                callback,
+                onRetry,
+            )
         }
     }
 }


### PR DESCRIPTION
### Проблема:
Среди запросов существуют те, которые выполняются значительно дольше заявленного времени `requestAverageProcessingTime`.

### Гипотеза:
Мы составили график квантилей на основе времени препровождения запросов в системе и посмотрели на ситуацию.
![telegram-cloud-photo-size-2-5217944038814716016-y](https://github.com/user-attachments/assets/61601f0d-cea5-4603-9f5c-4b4f0add0030)

Высокие квантили (0.90q и выше) показывали крайне высокий RT (response time), что навлекло нас на идею урезать максимальную длительность выполнения запроса.

### Что именно сделали:
Исходя из графиков выше, мы посмотрели, что 0.85q показывает хорошие результаты, нежели 0.90q и выше. В среднем, 0.85q равнялось 1700 миллисекундам, поэтому мы решили заменить `requestAverageProcessingTime` на это самое значение.

### Почему это работает:
При помощи таймаута мы сразу отрезаем часть запросов, которые внезапно захотели выполняться дольше положенного, но при этом большая часть запросов (85%) должны проходить вообще без проблем. А если совместить таймауты с ретраями из прошлого кейса, то получается вполне отличная комбинация - таким образом мы уменьшаем шанс фейла запроса из-за какой-нибудь флакающей ошибки на стороне сервера, из-за которой этот запрос занимает значительно больше времени, чем на самом деле необходимо.

![telegram-cloud-photo-size-2-5217944038814715993-y](https://github.com/user-attachments/assets/9020d2da-b13f-4e99-b99b-9426b02a39b1)
![telegram-cloud-photo-size-2-5217944038814715994-y](https://github.com/user-attachments/assets/87f1f8ad-2411-4a30-bb7a-d35406949316)

График с ретраями:
<img width="667" height="259" alt="image" src="https://github.com/user-attachments/assets/0b9b13a9-e1c2-4f1d-9e74-64cfff12aa24" />
