### PR TITLE
Case 8. Thread Pool

### DIFF
--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -35,8 +35,8 @@ class OrderPayer {
     private lateinit var paymentService: PaymentService
 
     private val paymentExecutor = ThreadPoolExecutor(
-        16,
-        16,
+        50,
+        50,
         0L,
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(8_000),
@@ -44,8 +44,8 @@ class OrderPayer {
         CallerBlockingRejectedExecutionHandler()
     )
 
-    private val outgoingRps = 8.0
-    private val reqProcessingTime = 1700L // ms
+    private val outgoingRps = 100.0
+    private val reqProcessingTime = 500L // ms
 
     private val slidingWindow = SlidingWindowRateLimiter(
         outgoingRps.toLong(),

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -45,7 +45,7 @@ class OrderPayer {
     )
 
     private val outgoingRps = 100.0
-    private val reqProcessingTime = 500L // ms
+    private val reqProcessingTime = 3000L // ms
 
     private val slidingWindow = SlidingWindowRateLimiter(
         outgoingRps.toLong(),

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -76,7 +76,6 @@ class PaymentExternalSystemAdapterImpl(
 
         val baseDelay = 100L // ms
         val maxDelay = 16000L // ms
-        val quantileProcessingTime = 1700L // ms
 
         repeat(8) { attempt ->
             var shouldRetry = false
@@ -85,8 +84,8 @@ class PaymentExternalSystemAdapterImpl(
                 ongoingWindow.acquire()
                 rateLimiter.tickBlocking()
 
-                if (deadline < now() + quantileProcessingTime) {
-                    throw ShouldRetryException(now() + quantileProcessingTime)
+                if (deadline < now() + requestAverageProcessingTime.toMillis()) {
+                    throw ShouldRetryException(now() + requestAverageProcessingTime.toMillis())
                 }
 
                 val request = Request.Builder().run {
@@ -96,7 +95,7 @@ class PaymentExternalSystemAdapterImpl(
 
                 val clientWithTimeout = client
                     .newBuilder()
-                    .callTimeout(quantileProcessingTime, TimeUnit.MILLISECONDS)
+                    .callTimeout(requestAverageProcessingTime.toMillis(), TimeUnit.MILLISECONDS)
                     .build()
 
                 clientWithTimeout

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import okhttp3.ConnectionPool
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.LoggerFactory
@@ -45,7 +47,10 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val client = OkHttpClient.Builder().build()
+    private val client = OkHttpClient.Builder()
+        .connectionPool(ConnectionPool(150, 10000, TimeUnit.MILLISECONDS))
+        .protocols(listOf(Protocol.H2_PRIOR_KNOWLEDGE))
+        .build()
 
     private val rateLimiter = SlidingWindowRateLimiter(
         rateLimitPerSec.toLong(),
@@ -76,6 +81,7 @@ class PaymentExternalSystemAdapterImpl(
 
         val baseDelay = 100L // ms
         val maxDelay = 16000L // ms
+        val quantileProcessingTime = 3000 // ms
 
         repeat(8) { attempt ->
             var shouldRetry = false
@@ -84,8 +90,8 @@ class PaymentExternalSystemAdapterImpl(
                 ongoingWindow.acquire()
                 rateLimiter.tickBlocking()
 
-                if (deadline < now() + requestAverageProcessingTime.toMillis()) {
-                    throw ShouldRetryException(now() + requestAverageProcessingTime.toMillis())
+                if (deadline < now() + quantileProcessingTime) {
+                    throw ShouldRetryException(now() + quantileProcessingTime)
                 }
 
                 val request = Request.Builder().run {
@@ -95,7 +101,7 @@ class PaymentExternalSystemAdapterImpl(
 
                 val clientWithTimeout = client
                     .newBuilder()
-                    .callTimeout(requestAverageProcessingTime.toMillis(), TimeUnit.MILLISECONDS)
+                    .callTimeout(quantileProcessingTime.toLong(), TimeUnit.MILLISECONDS)
                     .build()
 
                 clientWithTimeout


### PR DESCRIPTION
### Проблема:
Запросы быстро начинают падать, при этом количество Retry-After в заголовках сильно увеличивается.
<img width="1111" height="324" alt="Снимок экрана 2025-11-13 в 21 54 02" src="https://github.com/user-attachments/assets/2f151bab-0f9b-4e86-9a13-ad876df59afe" />
<img width="898" height="458" alt="Снимок экрана 2025-11-13 в 21 54 08" src="https://github.com/user-attachments/assets/52fd902b-fcf1-4296-b55b-3f2714b4e42e" />

### Гипотеза:
Мы предположили, что это происходит по двум причинам:
- Малое количество тредов на обработку
- Необходимо выделить connection pool в `OkHttpClient` для переиспользования коннекшенов

Если их исправить, то проблема решится.

### Что именно сделали:
Изначально тредпул был размером 16 тредов. Давайте посчитаем, сколько же на самом деле необходимо. Посмотрим на свойства аккаунта `acc-9`: `120 rps`, `50 parallelRequests` и `0.5s avg processing time`.
За секунду мы по факту можем обработать 1 / 0.5 = 2 запроса. А пропускная способность аккаунта - это `min(120, 50/0.5) = 100 rps`. Чтоб по максимуму утилизировать его, нам нужно 100 / 2 = 50 тредов в нашем пуле. А их меньше более чем в 3 раза!

Поэтому, мы увеличили размер `ThreadPoolExecutor` до 50.

Мы также заиспользовали `ConnectionPool` для `OkHttpClient`, выставив ему размер 150 (для 100 соединений под рпс и 50 сверху, на всякий случай). `KeepAliveTime` поставили 10 секунд - в целом, под наш кейс более чем подходит.

Дополнительно, как и в бонусном 7 кейсе, мы решили прибегнуть к использованию протокола `h2_prior_knowledge`, чтоб наш сервис и сервис оплаты пользовались виртуальными соединениями.

`callTimeout` повысили до целых трех секунд, потому что, судя по графику квантилей времени обработки запросов, `avgProcessingTime` сильно отличается от настоящего времени обработки.
<img width="1156" height="642" alt="image" src="https://github.com/user-attachments/assets/b26e429a-8b1c-42e4-ad13-f004e49ccaac" />

### Почему это работает:
Увеличив размер `ThreadPoolExecutor`, мы стали утилизировать `acc-9` на максимум, достигнув лучшей производительности. Запросы перестали копиться в очереди, а мы достигли максимального параллелизма.

<img width="2232" height="974" alt="image" src="https://github.com/user-attachments/assets/c2723710-d45a-4ebc-ab86-8b538cc16156" />
<img width="2237" height="690" alt="image" src="https://github.com/user-attachments/assets/01451f91-d81d-45d1-913c-11284397f5cf" />

Количество заголовков `Retry-After` в респонсах упало в ноль.
<img width="912" height="270" alt="image" src="https://github.com/user-attachments/assets/6ee8744d-3e2c-40c1-a48c-c82b41a9c9dd" />

<img width="724" height="491" alt="image" src="https://github.com/user-attachments/assets/ffea709e-007e-473d-8cd1-13e8bfa6f1de" />
